### PR TITLE
Reakt Components

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DiscordProjectSettings">
     <option name="show" value="ASK" />

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -344,6 +344,9 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 component.document = document
             }
 
+            composition.components += component
+            composition.stack += document.stack
+
             flatten(document, composition)
         }
 

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -420,7 +420,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
     fun <T> writable(value: T): Writable<T> {
         val isInsideRenderMethod = StackWalker.getInstance().walk { stream ->
             val frame = stream
-                .limit(20)  // 7-8 frames is all we really need, but for safety purposes, we'll push to 20 frames
+                .limit(6) // 6 frames is usually where we can determine where the render method is called
                 .dropWhile { !(it.methodName == "render" && it.className.startsWith("pw.mihou.reakt")) }
                 .findFirst()
                 .getOrNull()

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -151,7 +151,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         internal fun <T> suggestions(exception: Throwable): T? {
             val message = exception.message ?: return null
             if (message.contains("COMPONENT_CUSTOM_ID_DUPLICATED")) {
-                logger.warn("RKT-939 This issue can happen when two or more components " +
+                logger.error("RKT-939 This issue can happen when two or more components " +
                         "(with Discord components, such as buttons) have no differentiating factors (such as a prop), " +
                         "leading to Reakt reusing the same render output for all of them. " +
                         "To resolve this issue, you may add the '%key' prop with a unique, identifying value that " +

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -346,6 +346,8 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             }
 
             composition.components += component
+            composition.stack += document.stack
+
             flatten(document, composition)
         }
 

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -268,8 +268,12 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 component.rerender()
             }
 
+            into.components += component
             into.stack += component.document.stack
-            flatten(component.document, into)
+
+            if (component.document.components.isNotEmpty()) {
+                flatten(component.document, into)
+            }
         }
     }
 

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -287,9 +287,9 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         val oldComponents = oldDocument.copyComponents()
 
         val newDocument = Document()
-        val newComponents = newDocument.copyComponents()
-
         renderer(newDocument)
+
+        val newComponents = newDocument.copyComponents()
 
         // @note list of components that were re-rendered, so we can reference it when there are duplicates.
         val renderedComponents = mutableListOf<Component>()

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -299,6 +299,10 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             }
             this.rendered = true
         } catch (err: Exception) {
+            // @note propogate upwards.
+            if (err is ReaktStateInsideRenderMethodException || err is ReaktComponentDuplicateException) {
+                throw err
+            }
             logger.error("An uncaught exception was received by Reakt's renderer with the following stacktrace.", err)
         }
     }

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -152,7 +152,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         internal fun <T> suggestions(exception: Throwable): T? {
             val message = exception.message ?: return null
             if (message.contains("COMPONENT_CUSTOM_ID_DUPLICATED")) {
-                throw ReaktComponentDuplicateException
+                throw ReaktComponentDuplicateException(message)
             } else {
                 logger.error("Failed to re-render message using Reakt with the following stacktrace.", exception)
             }

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -745,10 +745,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             return _value.get().toString()
         }
 
-        override fun hashCode(): Int {
-            return _value.get().hashCode()
-        }
-
         override fun equals(other: Any?): Boolean {
             val value = _value.get()
             if (other == null && value == null) return true
@@ -789,6 +785,8 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 }
             }
             for ((key, value) in props) {
+                // when dealing with writable's origin value, ignore it.
+                if (key.endsWith(RESERVED_VALUE_KEY)) continue
                 inc(key, value)
             }
             inc(qualifiedName)

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -741,7 +741,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         }
     }
 
-    class Component internal constructor(val qualifiedName: String, private val constructor: ComponentConstructor) {
+    class Component internal constructor(private val qualifiedName: String, private val constructor: ComponentConstructor) {
 
         private var beforeMountListeners = mutableListOf<ComponentBeforeMountSubscription>()
         private var afterMountListeners = mutableListOf<ComponentAfterMountSubscription>()

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -904,7 +904,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 // to determine if the prop changed.
                 val copy = this.props.toMutableMap()
                 for ((key, value) in this.props) {
-                    if (value == null) return
+                    if (value == null) break
                     when(value) {
                         is Writable<*>, is ReadOnly<*> ->  {
                             copy["$key$RESERVED_VALUE_KEY"] = when(value) {

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -21,6 +21,7 @@ import pw.mihou.reakt.channels.Endpoint
 import pw.mihou.reakt.deferrable.ReaktMessage
 import pw.mihou.reakt.exceptions.NoRenderFoundException
 import pw.mihou.reakt.exceptions.PropTypeMismatch
+import pw.mihou.reakt.exceptions.ReaktComponentDuplicateException
 import pw.mihou.reakt.exceptions.UnknownPropException
 import pw.mihou.reakt.logger.LoggingAdapter
 import pw.mihou.reakt.logger.adapters.DefaultLoggingAdapter
@@ -151,11 +152,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         internal fun <T> suggestions(exception: Throwable): T? {
             val message = exception.message ?: return null
             if (message.contains("COMPONENT_CUSTOM_ID_DUPLICATED")) {
-                logger.error("RKT-939 This issue can happen when two or more components " +
-                        "(with Discord components, such as buttons) have no differentiating factors (such as a prop), " +
-                        "leading to Reakt reusing the same render output for all of them. " +
-                        "To resolve this issue, you may add the '%key' prop with a unique, identifying value that " +
-                        "identifies the component. (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)", exception)
+                throw ReaktComponentDuplicateException
             } else {
                 logger.error("Failed to re-render message using Reakt with the following stacktrace.", exception)
             }

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -419,12 +419,13 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
      */
     fun <T> writable(value: T): Writable<T> {
         val isInsideRenderMethod = StackWalker.getInstance().walk { stream ->
-            val firstFrame = stream
-                .skip(1)
+            val frame = stream
+                .limit(20)  // 7-8 frames is all we really need, but for safety purposes, we'll push to 20 frames
+                .dropWhile { !(it.methodName == "render" && it.className.startsWith("pw.mihou.reakt")) }
                 .findFirst()
-                .get()
+                .getOrNull()
 
-            return@walk firstFrame.methodName == "render" && firstFrame.className.startsWith("pw.mihou.reakt")
+            return@walk frame != null
         }
         if (isInsideRenderMethod) {
             throw ReaktStateInsideRenderMethodException

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -268,9 +268,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 component.rerender()
             }
 
-            into.components += component
             into.stack += component.document.stack
-
             if (component.document.components.isNotEmpty()) {
                 flatten(component.document, into)
             }
@@ -323,11 +321,14 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 }
             }
 
-            for (component1 in oldComponents) {
-                val equivalent = component.compare(component1)
-                if (equivalent) {
-                    document = component1.document
-                    break
+            // @note only iterate older components when Reakt re-rendered.
+            if (rendered) {
+                for (component1 in oldComponents) {
+                    val equivalent = component.compare(component1)
+                    if (equivalent) {
+                        document = component1.document
+                        break
+                    }
                 }
             }
 
@@ -345,8 +346,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             }
 
             composition.components += component
-            composition.stack += document.stack
-
             flatten(document, composition)
         }
 
@@ -926,10 +925,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         internal var listener: GloballyAttachableListener? = null
         internal var uuid: String? = null
         internal var textContent: String? = null
-
-        fun append(stack: MutableStack) {
-            stack += this
-        }
 
         fun render(view: View) {
             val embed = embed

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -300,7 +300,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             this.rendered = true
         } catch (err: Exception) {
             // @note propogate upwards.
-            if (err is ReaktStateInsideRenderMethodException || err is ReaktComponentDuplicateException) {
+            if (err is ReaktRuleEnforcementException) {
                 throw err
             }
             logger.error("An uncaught exception was received by Reakt's renderer with the following stacktrace.", err)

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -268,7 +268,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 component.rerender()
             }
 
-            into.components += component
             into.stack += component.document.stack
             flatten(component.document, into)
         }
@@ -301,6 +300,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         val newDocument = Document()
         renderer(newDocument)
 
+        val composition = Document()
         val newComponents = newDocument.copyComponents()
 
         // @note list of components that were re-rendered, so we can reference it when there are duplicates.
@@ -340,13 +340,13 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 component.document = document
             }
 
-            flatten(document, newDocument)
+            flatten(document, composition)
         }
 
-        this.document = newDocument
+        this.document = composition
 
         val element = View()
-        for (stackElement in newDocument.stack) {
+        for (stackElement in composition.stack) {
             stackElement.render(element)
         }
         return element

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -776,8 +776,10 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             private set
         private var constructed = false
 
-        val session = componentSessions.computeIfAbsent(hashCode) {
-            ComponentStore()
+        val session by lazy {
+            componentSessions.computeIfAbsent(hashCode) {
+                ComponentStore()
+            }
         }
         private val hashCode get(): Int {
             var result = 1

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -368,6 +368,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 // ensure that we swap the document inside the component
                 // so that the next rerender will utilize this new document.
                 component.document = equivalence.document
+                document = component.document
             }
 
             composition.components += component

--- a/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
@@ -27,12 +27,12 @@ fun <Interaction: InteractionBase> Interaction.R(ephemeral: Boolean, lifetime: D
         reakt(r)
 
         return@autoDefer r.message!!
-    }.exceptionally(Reakt::suggestions).thenApply {
+    }.thenApply {
         val message = it.getOrRequestMessage().join()
 
         r.interactionUpdater = it.updater
         r.acknowledgeUpdate(message)
 
         return@thenApply it
-    }
+    }.exceptionally(Reakt::suggestions)
 }

--- a/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
@@ -27,7 +27,7 @@ fun <Interaction: InteractionBase> Interaction.R(ephemeral: Boolean, lifetime: D
         reakt(r)
 
         return@autoDefer r.message!!
-    }.thenApply {
+    }.exceptionally(Reakt::suggestions).thenApply {
         val message = it.getOrRequestMessage().join()
 
         r.interactionUpdater = it.updater

--- a/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
@@ -17,7 +17,7 @@ import kotlin.time.Duration.Companion.hours
  * @param react the [Reakt] instance.
  */
 private fun CompletableFuture<Message>.ack(react: Reakt): CompletableFuture<Message> {
-    return this.thenApply { message ->
+    return this.exceptionally(Reakt::suggestions).thenApply { message ->
         react.acknowledgeUpdate(message)
         return@thenApply message
     }

--- a/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
@@ -17,10 +17,10 @@ import kotlin.time.Duration.Companion.hours
  * @param react the [Reakt] instance.
  */
 private fun CompletableFuture<Message>.ack(react: Reakt): CompletableFuture<Message> {
-    return this.exceptionally(Reakt::suggestions).thenApply { message ->
+    return this.thenApply { message ->
         react.acknowledgeUpdate(message)
         return@thenApply message
-    }
+    }.exceptionally(Reakt::suggestions)
 }
 
 /**

--- a/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
@@ -7,7 +7,7 @@ import org.javacord.api.listener.interaction.ButtonClickListener
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.uuid.UuidGenerator
 
-fun Reakt.Component.PrimaryButton(
+fun Reakt.View.PrimaryButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -15,7 +15,7 @@ fun Reakt.Component.PrimaryButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.PRIMARY, label, customId, emoji, disabled, onClick)
 
-fun Reakt.Component.SecondaryButton(
+fun Reakt.View.SecondaryButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -23,7 +23,7 @@ fun Reakt.Component.SecondaryButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.SECONDARY, label, customId, emoji, disabled, onClick)
 
-fun Reakt.Component.SuccessButton(
+fun Reakt.View.SuccessButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -31,7 +31,7 @@ fun Reakt.Component.SuccessButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.SUCCESS, label, customId, emoji, disabled, onClick)
 
-fun Reakt.Component.DangerButton(
+fun Reakt.View.DangerButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -39,7 +39,7 @@ fun Reakt.Component.DangerButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.DANGER, label, customId, emoji, disabled, onClick)
 
-fun Reakt.Component.Button(
+fun Reakt.View.Button(
     style: ButtonStyle = ButtonStyle.PRIMARY,
     label: String,
     customId: String? = null,
@@ -65,7 +65,7 @@ fun Reakt.Component.Button(
     button.setCustomId(uuid)
 
     if (onClick != null) {
-        listeners += ButtonClickListener {
+        reference.listeners += ButtonClickListener {
             if (it.buttonInteraction.customId != uuid) {
                 return@ButtonClickListener
             }
@@ -74,5 +74,5 @@ fun Reakt.Component.Button(
         }
     }
 
-    components += button.build()
+    reference.components += button.build()
 }

--- a/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
@@ -39,14 +39,25 @@ fun Reakt.Document.DangerButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.DANGER, label, customId, emoji, disabled, onClick)
 
+typealias ReaktButtonClickListener = ((event: ButtonClickEvent) -> Unit)
+
+@Suppress("NAME_SHADOWING")
 fun Reakt.Document.Button(
     style: ButtonStyle = ButtonStyle.PRIMARY,
     label: String,
     customId: String? = null,
     emoji: String? = null,
     disabled: Boolean = false,
-    onClick: ((event: ButtonClickEvent) -> Unit)? = null
+    onClick: ReaktButtonClickListener? = null
 ) = component {
+
+    val style =  ensureProp<ButtonStyle>("style")
+    val label = ensureProp<String>("label")
+    val customId = prop<String>("customId")
+    val emoji = prop<String>("emoji")
+    val disabled = ensureProp<Boolean>("disabled")
+    val onClick = prop<ReaktButtonClickListener>("onClick")
+
     render {
         // @native directly injects a button element into the stack.
         document.stack {
@@ -79,4 +90,5 @@ fun Reakt.Document.Button(
             component = button.build()
         }
     }
-}() // @note auto-invoke component upon creation.
+}("style" to style, "label" to label, "customId" to customId,
+    "emoji"  to emoji, "disabled" to disabled, "onclick" to onClick) // @note auto-invoke component upon creation.

--- a/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
@@ -49,7 +49,7 @@ fun Reakt.Document.Button(
     emoji: String? = null,
     disabled: Boolean = false,
     onClick: ReaktButtonClickListener? = null
-) = component {
+) = component("pw.mihou.reakt.elements.Button") {
 
     val style =  ensureProp<ButtonStyle>("style")
     val label = ensureProp<String>("label")

--- a/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Button.kt
@@ -7,7 +7,7 @@ import org.javacord.api.listener.interaction.ButtonClickListener
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.uuid.UuidGenerator
 
-fun Reakt.View.PrimaryButton(
+fun Reakt.Document.PrimaryButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -15,7 +15,7 @@ fun Reakt.View.PrimaryButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.PRIMARY, label, customId, emoji, disabled, onClick)
 
-fun Reakt.View.SecondaryButton(
+fun Reakt.Document.SecondaryButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -23,7 +23,7 @@ fun Reakt.View.SecondaryButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.SECONDARY, label, customId, emoji, disabled, onClick)
 
-fun Reakt.View.SuccessButton(
+fun Reakt.Document.SuccessButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -31,7 +31,7 @@ fun Reakt.View.SuccessButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.SUCCESS, label, customId, emoji, disabled, onClick)
 
-fun Reakt.View.DangerButton(
+fun Reakt.Document.DangerButton(
     label: String,
     customId: String? = null,
     emoji: String? = null,
@@ -39,40 +39,44 @@ fun Reakt.View.DangerButton(
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
 ) = Button(ButtonStyle.DANGER, label, customId, emoji, disabled, onClick)
 
-fun Reakt.View.Button(
+fun Reakt.Document.Button(
     style: ButtonStyle = ButtonStyle.PRIMARY,
     label: String,
     customId: String? = null,
     emoji: String? = null,
     disabled: Boolean = false,
     onClick: ((event: ButtonClickEvent) -> Unit)? = null
-) {
-    val button = ButtonBuilder()
-    button.setStyle(style)
-    button.setLabel(label)
+) = component {
+    render {
+        // @native directly injects a button element into the stack.
+        document.stack {
+            val button = ButtonBuilder()
+            button.setStyle(style)
+            button.setLabel(label)
 
-    if (emoji != null) {
-        button.setEmoji(emoji)
-    }
-
-    button.setDisabled(disabled)
-
-    val uuid = customId ?: run {
-        val id = UuidGenerator.request()
-        uuids.add(id)
-        return@run id
-    }
-    button.setCustomId(uuid)
-
-    if (onClick != null) {
-        reference.listeners += ButtonClickListener {
-            if (it.buttonInteraction.customId != uuid) {
-                return@ButtonClickListener
+            if (emoji != null) {
+                button.setEmoji(emoji)
             }
 
-            onClick(it)
+            button.setDisabled(disabled)
+
+            val uuid = customId ?: run {
+                uuid = UuidGenerator.request()
+                return@run uuid
+            }
+            button.setCustomId(uuid)
+
+            if (onClick != null) {
+                listener = ButtonClickListener {
+                    if (it.buttonInteraction.customId != uuid) {
+                        return@ButtonClickListener
+                    }
+
+                    onClick(it)
+                }
+            }
+
+            component = button.build()
         }
     }
-
-    reference.components += button.build()
-}
+}() // @note auto-invoke component upon creation.

--- a/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
@@ -12,17 +12,19 @@ import java.io.File
 import java.io.InputStream
 import java.time.Instant
 
-fun Reakt.Document.Embed(embed: Embed.() -> Unit) = component {
+typealias ReaktEmbedConstructor = Embed.() -> Unit
+fun Reakt.Document.Embed(embed: ReaktEmbedConstructor) = component {
+    val constructor = ensureProp<ReaktEmbedConstructor>("constructor")
     render {
         // @native directly injects an embed element into the stack.
         document.stack {
             val element = Embed()
-            embed(element)
+            constructor(element)
 
             this.embed = element.embed
         }
     }
-}() // @note auto-invoke component upon creation.
+}("constructor"  to embed) // @note auto-invoke component upon creation.
 
 class Embed {
     internal val embed = EmbedBuilder()

--- a/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
@@ -12,12 +12,17 @@ import java.io.File
 import java.io.InputStream
 import java.time.Instant
 
-fun Reakt.View.Embed(embed: Embed.() -> Unit) {
-    val element = Embed()
-    embed(element)
+fun Reakt.Document.Embed(embed: Embed.() -> Unit) = component {
+    render {
+        // @native directly injects an embed element into the stack.
+        document.stack {
+            val element = Embed()
+            embed(element)
 
-    reference.embeds.add(element.embed)
-}
+            this.embed = element.embed
+        }
+    }
+}() // @note auto-invoke component upon creation.
 
 class Embed {
     internal val embed = EmbedBuilder()

--- a/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
@@ -12,11 +12,11 @@ import java.io.File
 import java.io.InputStream
 import java.time.Instant
 
-fun Reakt.Component.Embed(embed: Embed.() -> Unit) {
+fun Reakt.View.Embed(embed: Embed.() -> Unit) {
     val element = Embed()
     embed(element)
 
-    embeds.add(element.embed)
+    reference.embeds.add(element.embed)
 }
 
 class Embed {

--- a/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Embed.kt
@@ -13,7 +13,7 @@ import java.io.InputStream
 import java.time.Instant
 
 typealias ReaktEmbedConstructor = Embed.() -> Unit
-fun Reakt.Document.Embed(embed: ReaktEmbedConstructor) = component {
+fun Reakt.Document.Embed(embed: ReaktEmbedConstructor) = component("pw.mihou.reakt.elements.Embed") {
     val constructor = ensureProp<ReaktEmbedConstructor>("constructor")
     render {
         // @native directly injects an embed element into the stack.

--- a/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
@@ -11,15 +11,27 @@ import org.javacord.api.listener.interaction.SelectMenuChooseListener
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.uuid.UuidGenerator
 
+typealias ReaktSelectMenuSelectListener = ((event: SelectMenuChooseEvent) -> Unit)
+typealias ReaktSelectMenuConstructor = SelectMenu.() -> Unit
+@Suppress("NAME_SHADOWING")
 fun Reakt.Document.SelectMenu(
     componentType: ComponentType,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
     maximumValues: Int = 1,
     disabled: Boolean = false,
-    onSelect: ((event: SelectMenuChooseEvent) -> Unit)? = null,
-    selectMenu: SelectMenu.() -> Unit
+    onSelect: ReaktSelectMenuSelectListener? = null,
+    selectMenu: ReaktSelectMenuConstructor
 ) =  component {
+
+    val componentType = ensureProp<ComponentType>("componentType")
+    val customId = ensureProp<String>("customId")
+    val minimumValues = ensureProp<Int>("minimumValues")
+    val maximumValues = ensureProp<Int>("maximumValues")
+    val disabled = ensureProp<Boolean>("disabled")
+    val onSelect = prop<ReaktSelectMenuSelectListener>("onSelect")
+    val selectMenu = ensureProp<ReaktSelectMenuConstructor>("constructor")
+
     render {
         // @native directly injects a select menu into the stack.
         document.stack {
@@ -45,7 +57,10 @@ fun Reakt.Document.SelectMenu(
             component = element.selectMenu.build()
         }
     }
-}() // @note auto-invoke component upon creation.
+}(
+    "componentType" to componentType, "customId" to customId, "minimumValues" to minimumValues,
+    "maximumValues"  to maximumValues, "disabled" to disabled, "onSelect" to onSelect,
+    "constructor" to selectMenu) // @note auto-invoke component upon creation.
 
 fun Reakt.Document.ChannelSelectMenu(
     types: Set<ChannelType>,

--- a/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
@@ -11,7 +11,7 @@ import org.javacord.api.listener.interaction.SelectMenuChooseListener
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.uuid.UuidGenerator
 
-fun Reakt.View.SelectMenu(
+fun Reakt.Document.SelectMenu(
     componentType: ComponentType,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -19,28 +19,35 @@ fun Reakt.View.SelectMenu(
     disabled: Boolean = false,
     onSelect: ((event: SelectMenuChooseEvent) -> Unit)? = null,
     selectMenu: SelectMenu.() -> Unit
-) {
-    val element = SelectMenu(
-        SelectMenuBuilder(componentType, customId)
-            .setDisabled(disabled)
-            .setMaximumValues(maximumValues)
-            .setMinimumValues(minimumValues))
-    selectMenu(element)
+) =  component {
+    render {
+        // @native directly injects a select menu into the stack.
+        document.stack {
+            val element = SelectMenu(
+                SelectMenuBuilder(componentType, customId)
+                    .setDisabled(disabled)
+                    .setMaximumValues(maximumValues)
+                    .setMinimumValues(minimumValues))
+            selectMenu(element)
 
-    if (onSelect != null) {
-        reference.listeners += SelectMenuChooseListener {
-            if (it.selectMenuInteraction.customId != customId) {
-                return@SelectMenuChooseListener
+            if (onSelect != null) {
+                listener = SelectMenuChooseListener {
+                    if (it.selectMenuInteraction.customId != customId) {
+                        return@SelectMenuChooseListener
+                    }
+
+                    onSelect(it)
+                }
+
+                uuid = customId
             }
 
-            onSelect(it)
+            component = element.selectMenu.build()
         }
     }
+}() // @note auto-invoke component upon creation.
 
-    reference.components += element.selectMenu.build()
-}
-
-fun Reakt.View.ChannelSelectMenu(
+fun Reakt.Document.ChannelSelectMenu(
     types: Set<ChannelType>,
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
@@ -60,7 +67,7 @@ fun Reakt.View.ChannelSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.View.ChannelSelectMenu(
+fun Reakt.Document.ChannelSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -78,7 +85,7 @@ fun Reakt.View.ChannelSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.View.UserSelectMenu(
+fun Reakt.Document.UserSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -96,7 +103,7 @@ fun Reakt.View.UserSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.View.MentionableSelectMenu(
+fun Reakt.Document.MentionableSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -114,7 +121,7 @@ fun Reakt.View.MentionableSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.View.SelectMenu(
+fun Reakt.Document.SelectMenu(
     options: List<SelectMenuOption>,
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),

--- a/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
@@ -22,7 +22,7 @@ fun Reakt.Document.SelectMenu(
     disabled: Boolean = false,
     onSelect: ReaktSelectMenuSelectListener? = null,
     selectMenu: ReaktSelectMenuConstructor
-) =  component {
+) =  component("pw.mihou.reakt.elements.SelectMenu") {
 
     val componentType = ensureProp<ComponentType>("componentType")
     val customId = ensureProp<String>("customId")

--- a/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/SelectMenu.kt
@@ -11,7 +11,7 @@ import org.javacord.api.listener.interaction.SelectMenuChooseListener
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.uuid.UuidGenerator
 
-fun Reakt.Component.SelectMenu(
+fun Reakt.View.SelectMenu(
     componentType: ComponentType,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -28,7 +28,7 @@ fun Reakt.Component.SelectMenu(
     selectMenu(element)
 
     if (onSelect != null) {
-        listeners += SelectMenuChooseListener {
+        reference.listeners += SelectMenuChooseListener {
             if (it.selectMenuInteraction.customId != customId) {
                 return@SelectMenuChooseListener
             }
@@ -37,10 +37,10 @@ fun Reakt.Component.SelectMenu(
         }
     }
 
-    components += element.selectMenu.build()
+    reference.components += element.selectMenu.build()
 }
 
-fun Reakt.Component.ChannelSelectMenu(
+fun Reakt.View.ChannelSelectMenu(
     types: Set<ChannelType>,
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
@@ -60,7 +60,7 @@ fun Reakt.Component.ChannelSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.Component.ChannelSelectMenu(
+fun Reakt.View.ChannelSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -78,7 +78,7 @@ fun Reakt.Component.ChannelSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.Component.UserSelectMenu(
+fun Reakt.View.UserSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -96,7 +96,7 @@ fun Reakt.Component.UserSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.Component.MentionableSelectMenu(
+fun Reakt.View.MentionableSelectMenu(
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),
     minimumValues: Int = 1,
@@ -114,7 +114,7 @@ fun Reakt.Component.MentionableSelectMenu(
     placeholder?.let { Placeholder(it) }
 }
 
-fun Reakt.Component.SelectMenu(
+fun Reakt.View.SelectMenu(
     options: List<SelectMenuOption>,
     placeholder: String? = null,
     customId: String = UuidGenerator.request(),

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -3,17 +3,19 @@ package pw.mihou.reakt.elements
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
-fun Reakt.Document.Text(text: Text.() -> Unit) = component {
+typealias ReaktTextConstructor = Text.() -> Unit
+fun Reakt.Document.Text(text: ReaktTextConstructor) = component {
+    val constructor =  ensureProp<ReaktTextConstructor>("constructor")
     render {
         // @native directly injects a text element into the stack.
         document.stack {
             val element = Text()
-            text(element)
+            constructor(element)
 
             textContent = element.content
         }
     }
-}() // @note auto-invoke component upon creation.
+}("constructor" to text) // @note auto-invoke component upon creation.
 
 class Text {
     internal var content: String = ""

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -3,12 +3,17 @@ package pw.mihou.reakt.elements
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
-fun Reakt.View.Text(text: Text.() -> Unit) {
-    val element = Text()
-    text(element)
+fun Reakt.Document.Text(text: Text.() -> Unit) = component {
+    render {
+        // @native directly injects a text element into the stack.
+        document.stack {
+            val element = Text()
+            text(element)
 
-    reference.contents = element.content
-}
+            textContent = element.content
+        }
+    }
+}() // @note auto-invoke component upon creation.
 
 class Text {
     internal var content: String = ""

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -4,7 +4,7 @@ import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
 typealias ReaktTextConstructor = Text.() -> Unit
-fun Reakt.Document.Text(text: ReaktTextConstructor) = component {
+fun Reakt.Document.Text(text: ReaktTextConstructor) = component("pw.mihou.reakt.elements.Text") {
     val constructor =  ensureProp<ReaktTextConstructor>("constructor")
     render {
         // @native directly injects a text element into the stack.

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -4,7 +4,7 @@ import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
 typealias ReaktTextConstructor = BodyConstructor.() -> Unit
-fun Reakt.Document.Text(spaced: Boolean = false, constructor: ReaktTextConstructor) = component("pw.mihou.reakt.elements.Text") {
+fun Reakt.Document.Text(spaced: Boolean = true, constructor: ReaktTextConstructor) = component("pw.mihou.reakt.elements.Text") {
     @Suppress("NAME_SHADOWING") val constructor =  ensureProp<ReaktTextConstructor>("constructor")
     render {
         // @native directly injects a text element into the stack.

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -3,11 +3,11 @@ package pw.mihou.reakt.elements
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
-fun Reakt.Component.Text(text: Text.() -> Unit) {
+fun Reakt.View.Text(text: Text.() -> Unit) {
     val element = Text()
     text(element)
 
-    contents = element.content
+    reference.contents = element.content
 }
 
 class Text {

--- a/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/Text.kt
@@ -3,25 +3,15 @@ package pw.mihou.reakt.elements
 import pw.mihou.reakt.Reakt
 import pw.mihou.reakt.styles.BodyConstructor
 
-typealias ReaktTextConstructor = Text.() -> Unit
-fun Reakt.Document.Text(text: ReaktTextConstructor) = component("pw.mihou.reakt.elements.Text") {
-    val constructor =  ensureProp<ReaktTextConstructor>("constructor")
+typealias ReaktTextConstructor = BodyConstructor.() -> Unit
+fun Reakt.Document.Text(spaced: Boolean = false, constructor: ReaktTextConstructor) = component("pw.mihou.reakt.elements.Text") {
+    @Suppress("NAME_SHADOWING") val constructor =  ensureProp<ReaktTextConstructor>("constructor")
     render {
         // @native directly injects a text element into the stack.
         document.stack {
-            val element = Text()
-            constructor(element)
-
-            textContent = element.content
+            val bodyConstructor = BodyConstructor(autoAppendNewLines = spaced)
+            constructor(bodyConstructor)
+            textContent = bodyConstructor.content
         }
     }
-}("constructor" to text) // @note auto-invoke component upon creation.
-
-class Text {
-    internal var content: String = ""
-    fun Body(spaced: Boolean = false, builder: BodyConstructor.() -> Unit) {
-        val constructor = BodyConstructor(autoAppendNewLines = spaced)
-        builder(constructor)
-        content = constructor.content
-    }
-}
+}("spaced" to spaced, "constructor" to constructor) // @note auto-invoke component upon creation.

--- a/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
@@ -5,7 +5,7 @@ import org.javacord.api.entity.message.component.ButtonStyle
 import pw.mihou.reakt.Reakt
 
 @Suppress("NAME_SHADOWING")
-fun Reakt.Document.UrlButton(label: String, url: String, emoji: String? = null) = component {
+fun Reakt.Document.UrlButton(label: String, url: String, emoji: String? = null) = component("pw.mihou.reakt.elements.UrlButton") {
     val label = ensureProp<String>("label")
     val url = ensureProp<String>("url")
     val emoji = prop<String>("emoji")

--- a/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
@@ -4,7 +4,11 @@ import org.javacord.api.entity.message.component.ButtonBuilder
 import org.javacord.api.entity.message.component.ButtonStyle
 import pw.mihou.reakt.Reakt
 
+@Suppress("NAME_SHADOWING")
 fun Reakt.Document.UrlButton(label: String, url: String, emoji: String? = null) = component {
+    val label = ensureProp<String>("label")
+    val url = ensureProp<String>("url")
+    val emoji = prop<String>("emoji")
     render {
         // @native directly injects a button into the stack.
         stack {
@@ -20,4 +24,4 @@ fun Reakt.Document.UrlButton(label: String, url: String, emoji: String? = null) 
             component = button.build()
         }
     }
-}() // @note auto-invoke component upon creation.
+}("label" to label, "url" to url, "emoji" to emoji) // @note auto-invoke component upon creation.

--- a/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
@@ -4,7 +4,7 @@ import org.javacord.api.entity.message.component.ButtonBuilder
 import org.javacord.api.entity.message.component.ButtonStyle
 import pw.mihou.reakt.Reakt
 
-fun Reakt.Component.UrlButton(label: String, url: String, emoji: String? = null) {
+fun Reakt.View.UrlButton(label: String, url: String, emoji: String? = null) {
     val button = ButtonBuilder()
     button.setStyle(ButtonStyle.LINK)
     button.setLabel(label)
@@ -14,5 +14,5 @@ fun Reakt.Component.UrlButton(label: String, url: String, emoji: String? = null)
         button.setEmoji(emoji)
     }
 
-    components += button.build()
+    reference.components += button.build()
 }

--- a/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
+++ b/src/main/kotlin/pw/mihou/reakt/elements/UrlButton.kt
@@ -4,15 +4,20 @@ import org.javacord.api.entity.message.component.ButtonBuilder
 import org.javacord.api.entity.message.component.ButtonStyle
 import pw.mihou.reakt.Reakt
 
-fun Reakt.View.UrlButton(label: String, url: String, emoji: String? = null) {
-    val button = ButtonBuilder()
-    button.setStyle(ButtonStyle.LINK)
-    button.setLabel(label)
-    button.setUrl(url)
+fun Reakt.Document.UrlButton(label: String, url: String, emoji: String? = null) = component {
+    render {
+        // @native directly injects a button into the stack.
+        stack {
+            val button = ButtonBuilder()
+            button.setStyle(ButtonStyle.LINK)
+            button.setLabel(label)
+            button.setUrl(url)
 
-    if (emoji != null) {
-        button.setEmoji(emoji)
+            if (emoji != null) {
+                button.setEmoji(emoji)
+            }
+
+            component = button.build()
+        }
     }
-
-    reference.components += button.build()
-}
+}() // @note auto-invoke component upon creation.

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/NoRenderFoundException.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/NoRenderFoundException.kt
@@ -1,5 +1,3 @@
 package pw.mihou.reakt.exceptions
 
-object NoRenderFoundException: RuntimeException("No render method was identified in a Reakt component.") {
-    private fun readResolve(): Any = NoRenderFoundException
-}
+class NoRenderFoundException(qualifiedName: String): RuntimeException("No render method was identified in the Reakt component '$qualifiedName'.")

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/NoRenderFoundException.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/NoRenderFoundException.kt
@@ -1,0 +1,5 @@
+package pw.mihou.reakt.exceptions
+
+object NoRenderFoundException: RuntimeException("No render method was identified in a Reakt component.") {
+    private fun readResolve(): Any = NoRenderFoundException
+}

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/PropExceptions.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/PropExceptions.kt
@@ -1,0 +1,5 @@
+package pw.mihou.reakt.exceptions
+
+class UnknownPropException(prop: String): RuntimeException("Unknown prop '$prop'.")
+class PropTypeMismatch(prop: String, expected: Class<*>, found: Class<*>):
+    RuntimeException("Expected prop '$prop' to be of ${expected.name} but found ${found.name} instead.")

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
@@ -1,18 +1,28 @@
 package pw.mihou.reakt.exceptions
 
-class ReaktComponentDuplicateException(message: String): RuntimeException("RKT-939 This issue can happen when two or more components " +
-        "(with Discord components, such as buttons) have no differentiating factors (such as a prop), " +
-        "leading to Reakt reusing the same render output for all of them. " +
-        "To resolve this issue, you may add the '%key' prop with a unique, identifying value that " +
-        "identifies the component. (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)." +
-        "\n" +
-        message
-)
 
-object ReaktStateInsideRenderMethodException: RuntimeException("RKT-748 You cannot create a subscribed state inside the `render` method. " +
-        "Creating a state inside the `render` method causes it to recreate itself for every time the `render` method is called, creating " +
-        "waste. To resolve this issue, move the state declaration outside of the `render` method. " +
-        "(Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)."
+open class ReaktRuleEnforcementException(code: Int, message: String, additionalData: String? = null):
+    RuntimeException(
+        "RKT-$code $message (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)." +
+                if (additionalData != null) "\n$additionalData"
+                else ""
+    )
+
+class ReaktComponentDuplicateException(message: String):
+    ReaktRuleEnforcementException(
+        code = 939,
+        message = "This issue can happen when two or more components (with Discord components, such as buttons) " +
+                "have no differentiating factors (such as a prop), leading to Reakt reusing the same render " +
+                "output for all of them. To resolve this issue, you may add the '%key' prop with a unique, " +
+                "identifying value that identifies the component.",
+        additionalData = message
+    )
+
+object ReaktStateInsideRenderMethodException:  ReaktRuleEnforcementException(
+    code = 748,
+    message = "You cannot create a subscribed state inside the `render` method. " +
+            "Creating a state inside the `render` method causes it to recreate itself for every time the `render` method is called, creating " +
+            "waste. To resolve this issue, move the state declaration outside of the `render` method."
 ) {
     private fun readResolve(): Any = ReaktStateInsideRenderMethodException
 }

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
@@ -8,3 +8,11 @@ class ReaktComponentDuplicateException(message: String): RuntimeException("RKT-9
         "\n" +
         message
 )
+
+object ReaktStateInsideRenderMethodException: RuntimeException("RKT-748 You cannot create a subscribed state inside the `render` method. " +
+        "Creating a state inside the `render` method causes it to recreate itself for every time the `render` method is called, creating " +
+        "waste. To resolve this issue, move the state declaration outside of the `render` method. " +
+        "(Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)."
+) {
+    private fun readResolve(): Any = ReaktStateInsideRenderMethodException
+}

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
@@ -1,0 +1,9 @@
+package pw.mihou.reakt.exceptions
+
+object ReaktComponentDuplicateException: RuntimeException("RKT-939 This issue can happen when two or more components " +
+        "(with Discord components, such as buttons) have no differentiating factors (such as a prop), " +
+        "leading to Reakt reusing the same render output for all of them. " +
+        "To resolve this issue, you may add the '%key' prop with a unique, identifying value that " +
+        "identifies the component. (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)") {
+    private fun readResolve(): Any = ReaktComponentDuplicateException
+}

--- a/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
+++ b/src/main/kotlin/pw/mihou/reakt/exceptions/RenderExceptions.kt
@@ -1,9 +1,10 @@
 package pw.mihou.reakt.exceptions
 
-object ReaktComponentDuplicateException: RuntimeException("RKT-939 This issue can happen when two or more components " +
+class ReaktComponentDuplicateException(message: String): RuntimeException("RKT-939 This issue can happen when two or more components " +
         "(with Discord components, such as buttons) have no differentiating factors (such as a prop), " +
         "leading to Reakt reusing the same render output for all of them. " +
         "To resolve this issue, you may add the '%key' prop with a unique, identifying value that " +
-        "identifies the component. (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)") {
-    private fun readResolve(): Any = ReaktComponentDuplicateException
-}
+        "identifies the component. (Read more at https://github.com/ShindouMihou/reakt.discord/wiki/Troubleshooting)." +
+        "\n" +
+        message
+)


### PR DESCRIPTION
A fundamental problem with the original implementation of Reakt was that it always re-rendered every element in its view whenever something changed, which means that components need to essentially be hooks for it to not re-fetch its data, or proceed with initialization all the time. Hooks work, but it takes more effort and develops a bad developer experience since you must restructure this object to different elements to get the component itself.

The components system aims to resolve many of those problems. Based on a differentiating mechanism, the components system identifies the difference between the past and present views. It checks whether any of the props of each component have changed and whether any of their states changed and re-renders the component when it does, otherwise reuses the previous render to prevent further re-rendering.

Fundamentally, this works with a similar concept to React.js' diffing algorithm, except that this is simpler and less advanced. Additionally, as `render` methods rely on function invocations rather than returning a `Component` object, we rely heavily on masking things out to make out the same feel. Passing props (or parameters) to `Components` is done with a variable argument of `Pair<String, Any?>`:
```kotlin
ComponentExample("prop1"  to "hello world", "prop2" to "hello galaxy")
```

And because the  `render` method doesn't rely on returning `Component` objects, this means that `Component` objects are unreliable to keep states as a new `Component` object is recreated every time. Instead, we provide methods such as `onBeforeMount` and `onAfterMount` to properly accommodate those specific needs. Additionally, a `session` is provided for every component which helps maintain states such as `writable` without conflicting with other similar `Component`s.

Type-safety and prop assistance are disabled because of this, but there are ways to work around this as will be seen in the example below.

## How to build a Component?

A component is simply an extension variable overlaid on `React.Document` which uses the `component` function to create a `Component` layout:
```kotlin
val React.Document.ComponentExample get() = component {
     val clicks by session.writable("clicks", 0)
     val name = ensureProp<String>("name");
     render {
        Text { 
           this append p("Hello ") + bold(name)
           this append p("You have clicked this message $clicks times.")
        }
    }
}
```

And to use the component, you have to invoke it, such as:
```kotlin
ComponentExample("name" to "Mihou")
```

But that presents a significant problem, and that is the type safety and assistance with what props the component can take. We can resolve that instead by switching from an extension variable to an extension function and calling the function ourselves:
```kotlin
fun React.Document.ComponentExample(name: String) = component {
     val clicks by session.writable("clicks", 0)
     val name = ensureProp<String>("name");
     render {
        Text { 
           this append p("Hello ") + bold(name)
           this append p("You have clicked this message $clicks times.")
        }
    }
}("name" to name)
```

The above pattern is what composes `Embed`, `Text`, `Button`, and `SelectMenu` (native elements in Reakt, but are still components). We add what parameters we want and invoke the component immediately with the props included, as seen with the closing bracket's line.

To use the component, it'd be the same as any regular function would:
```kotlin
ComponentExample("Mihou")
ComponentExample(name = "Mihou")
```

And that brings us to our next point, strict regulations within the components.

## Reakt Enforced Regulations

### Component Duplication Issue (RKT-939)

Component developers should make sure that when they use the previously mentioned functional pattern, they allow their users to provide a `%key` prop, and this has to do with a specific problem with the differentiating algorithm.

Let's think of a scenario, we have two components, they have the same properties (`name` = `mihou`, for example), but they should have a different `clicks` state. How are we able to differentiate between the two components, how should we know that these two components should be different?

We can't. As such, Reakt would simply render one of them first, and then reuse the rendered view of the earlier component onto the next same components, which can result in components (buttons, select menus) having the same `customId` which Discord dislikes.

To resolve this, developers can simply add another unique prop that is different from the two components, for example:
```kotlin
Component("name" to "Mihou")
Component("name" to "Mihou") // Duplicate conflict!  (Both of them have no differentiating factor)

Component("name" to "Mihou")
Component("%key" to "mihou_2", "name" to "Mihou") // Renders separately since there is a difference between the two.
```

As seen in the above example, we can see that the first part has no differentiating factor between the two. We can't distinguish whether both components should be the same, or not. It's in our mind that they should be different, but the algorithm cannot tell that because it cannot read minds. As such, we need to have something that can distinguish between the two components, and this is the `%key` property.

A `%key` property is a good practice to have as it lets the differentiating algorithm know that this component always has this `%key` which makes it faster to distinguish the equivalence between two components. You may use any other prop to distinguish, but we recommend `%key` as the differentiating prop as it's baked into the comparison algorithm and will significantly improve performance as it doesn't need to perform too many comparisons.

### `writable` in `render` issue (RKT-748)

Similar to React and other frameworks, the issue of having a state declared in a non-persisting location is a bad practice. Reakt.Discord always calls the `render` method when it needs to render a new view of the component and anything that was declared inside will be discarded as soon as possible, which means we cannot declare a state here.

As such, when attempting to initialize a state (such as a `writable`) inside a `render` method, you will encounter an exception called the `RKT-748` exception which is when a state was declared within a `render` method. We are strictly enforcing this rule to prevent a bad practice and undesired behavior.