### PR TITLE
Adds Render-On-Destroy support.

### DIFF
--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -227,6 +227,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             freeReferences()
             return
         }
+
         if (api.intents.contains(Intent.GUILD_MESSAGES) || api.intents.contains(Intent.DIRECT_MESSAGES)) {
             messageDeleteListenerManager?.remove()
             messageDeleteListenerManager = this.resultingMessage?.run {
@@ -234,6 +235,10 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                     destroy()
                 }
             }
+        }
+        destroyJob = if (lifetime.isInfinite()) null else coroutine {
+            delay(lifetime.inWholeMilliseconds)
+            destroy()
         }
         updateSubscribers.forEach {
             try {
@@ -529,10 +534,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                     rerender(render)
 
                     destroyJob?.cancel()
-                    destroyJob = if (lifetime.isInfinite()) null else coroutine {
-                        delay(lifetime.inWholeMilliseconds)
-                        destroy()
-                    }
                 }
                 mutex.unlock()
             } catch (err: Exception) {

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -27,6 +27,7 @@ import pw.mihou.reakt.utils.coroutine
 import pw.mihou.reakt.uuid.UuidGenerator
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.jvm.optionals.getOrNull
@@ -69,6 +70,8 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
     private var unsubscribe: Unsubscribe = {}
 
     private var render: ReactDocument? = null
+    private var renderOnDestroy: ReactDocument? = null
+
     private var document: Document? = Document()
 
     private var debounceTask: Job? = null
@@ -81,6 +84,8 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
 
     private var updateSubscribers = mutableListOf<UpdateSubscription>()
     private var expansions = mutableListOf<Unsubscribe>()
+
+    private val isDestroying = AtomicBoolean(false)
 
     private var destroyJob = if (lifetime.isInfinite()) null else coroutine {
         delay(lifetime.inWholeMilliseconds)
@@ -215,6 +220,13 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
      */
     internal fun acknowledgeUpdate(message: Message) {
         this.resultingMessage = message
+
+        // Do not execute `updateSubscribes` and others when `isDestroying` because we won't
+        // want any other accidental side  effects to happen, such as another state re-updating.
+        if (isDestroying.get()) {
+            freeReferences()
+            return
+        }
         if (api.intents.contains(Intent.GUILD_MESSAGES) || api.intents.contains(Intent.DIRECT_MESSAGES)) {
             messageDeleteListenerManager?.remove()
             messageDeleteListenerManager = this.resultingMessage?.run {
@@ -233,35 +245,65 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
     }
 
     /**
+     * [freeReferences] unsubscribes and clears any potential references to this [Reakt] instance.
+     * This replaces all nullables with null, all lists with empty lists and all others with empty
+     * variants, allowing the garbage collector to claim this instance.
+     */
+    private fun freeReferences() {
+        unsubscribe()
+        document = null
+        render = null
+
+        this.unsubscribe = {}
+        this.destroySubscribers = mutableListOf()
+        this.resultingMessage = null
+        this.interactionUpdater = null
+        this.updateSubscribers = mutableListOf()
+        this.messageUpdater = null
+        this.messageBuilder = null
+        this.renderSubscribers = mutableListOf()
+        this.message = null
+        this.debounceTask = null
+        this.destroyJob = null
+        this.expansions.forEach(Unsubscribe::invoke)
+        this.expansions = mutableListOf()
+        this.messageDeleteListenerManager?.remove()
+        this.messageDeleteListenerManager = null
+        this.componentSessions = mutableMapOf()
+        this.renderOnDestroy = null
+
+        isDestroying.set(false)
+    }
+
+    /**
      * Destroys any references to this [Reakt] instance. It is recommended to do this when
      * you no longer need the interactivity as this will free up a ton of unused memory that should've
      * been free.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     fun destroy() {
-        synchronized(destroySubscribers) {
-            destroySubscribers.forEach(DestroySubscription::invoke)
+        if (isDestroying.get()) return
+        destroySubscribers.forEach(DestroySubscription::invoke)
 
-            unsubscribe()
-            document = null
-            render = null
-
-            this.unsubscribe = {}
-            this.destroySubscribers = mutableListOf()
-            this.resultingMessage = null
-            this.interactionUpdater = null
-            this.updateSubscribers = mutableListOf()
-            this.messageUpdater = null
-            this.messageBuilder = null
-            this.renderSubscribers = mutableListOf()
-            this.message = null
-            this.debounceTask = null
-            this.destroyJob = null
-            this.expansions.forEach(Unsubscribe::invoke)
-            this.expansions = mutableListOf()
-            this.messageDeleteListenerManager?.remove()
-            this.messageDeleteListenerManager = null
-            this.componentSessions = mutableMapOf()
+        isDestroying.set(true)
+        val renderOnDestroy = renderOnDestroy
+        if (renderOnDestroy == null) {
+            freeReferences()
+            return
         }
+
+        // we don't free references here because ::acknowledgeUpdate will see [isDestroying] as [true] and
+        // will free references once it is updated, ensuring the update gets through.
+        rerender(renderOnDestroy)
+    }
+
+    /**
+     * [renderOnDestroy] renders the [renderer] whenever [Reakt] activates a destruction. This can be used to
+     * notify the user that they can no longer use this, or enable some retries to recreate the message.
+     */
+    @Suppress("UNUSED", "MemberVisibilityCanBePrivate")
+    fun renderOnDestroy(renderer: ReactDocument) {
+        renderOnDestroy = renderer
     }
 
     /**
@@ -445,6 +487,29 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
     }
 
     /**
+     * Re-renders the entire message with the given [render].
+     * @param render the render to re-render with.
+     */
+    private fun rerender(render: ReactDocument) {
+        this.unsubscribe()
+        if (this.document == null) return
+        val interactionUpdater = interactionUpdater
+        if (interactionUpdater != null) {
+            val view = apply(render)
+            this.unsubscribe = view.render(interactionUpdater, api)
+            interactionUpdater.update().exceptionally(::suggestions).thenAccept(::acknowledgeUpdate)
+        } else {
+            val message = resultingMessage
+            if (message != null) {
+                val updater = message.createUpdater()
+                val view = apply(render)
+                this.unsubscribe = view.render(updater, api)
+                updater.replaceMessage().exceptionally(::suggestions).thenAccept(::acknowledgeUpdate)
+            }
+        }
+    }
+
+    /**
      * Adds a [Subscription] that enables the [ReactView] to be re-rendered whenever the value of the [Writable]
      * changes, this is what [writable] uses internally to react to changes.
      * @param writable the writable to subscribe.
@@ -458,24 +523,10 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 debounceTask?.cancel()
                 debounceTask = coroutine {
                     delay(debounceMillis)
-                    this.unsubscribe()
-
                     debounceTask = null
+
                     if (this.document == null) return@coroutine
-                    val interactionUpdater = interactionUpdater
-                    if (interactionUpdater != null) {
-                        val view = apply(render)
-                        this.unsubscribe = view.render(interactionUpdater, api)
-                        interactionUpdater.update().exceptionally(::suggestions).thenAccept(::acknowledgeUpdate)
-                    } else {
-                        val message = resultingMessage
-                        if (message != null) {
-                            val updater = message.createUpdater()
-                            val view = apply(render)
-                            this.unsubscribe = view.render(updater, api)
-                            updater.replaceMessage().exceptionally(::suggestions).thenAccept(::acknowledgeUpdate)
-                        }
-                    }
+                    rerender(render)
 
                     destroyJob?.cancel()
                     destroyJob = if (lifetime.isInfinite()) null else coroutine {


### PR DESCRIPTION
Reakt's self-destruction mechanisms have been flawed for awhile now, it lacks notifying the user that "this message is no longer available" which can lead to confusion and misunderstandings. As such,  `renderOnDestroy` has been added to fill this gap. 

Render-On-Destroy is self-explanatory. It renders a specific view right before the destruction (freeing of references, allowing the garbage collector to reclaim the memory used by the Reakt instance) happens. This gives us ample time to notify the user that they can either use a global button listener to restart the process or notify them that they cannot use this message again.

A use-case identified by [Flyght](https://flyght.mihou.pw) is by having a "Retry" button that is attached to a global listener that will delete the original message and restarts the entire process again with a new `Reakt` instance.

> **Why not support resuming Reakt instances?**
> Resuming Reakt instances is also something that has been planned, but currently, the most effective and most efficient way of resuming sessions is to restart the entire process. This ensures that we clearly understand that we are starting from point zero. Although we do plan on supporting  `Reakt Sessions` which enables us to resume instances by recreating the `Reakt` instance but in a point-zero state (fresh based on what original constructor was used) and trigger the `onResume` with a `ResumeProperties` that will allow you to store specific states that will help in getting data from the database related to the session.