### PR TITLE
Hash code comparisons for stateful prop equivalence.

### DIFF
--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -482,6 +482,8 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                     if (!component.hasRenderedOnce) {
                         component.rerender()
                     }
+
+                    renderedComponents += component
                 } else {
                     if (equivalence.session.hasChanged) {
                         equivalence.session.hasChanged = false
@@ -493,7 +495,6 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
                 }
             } finally {
                 document = component.document
-                renderedComponents += component
             }
 
             composition.components += component

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -479,22 +479,23 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             }
 
             lateinit var document: Document
-            if (equivalence == null) {
-                if (!component.hasRenderedOnce) {
-                    component.rerender()
+            try {
+                if (equivalence == null) {
+                    if (!component.hasRenderedOnce) {
+                        component.rerender()
+                    }
+                } else {
+                    if (equivalence.session.hasChanged) {
+                        equivalence.session.hasChanged = false
+                        equivalence.rerender()
+                    }
+                    // ensure that we swap the document inside the component
+                    // so that the next rerender will utilize this new document.
+                    component.document = equivalence.document
                 }
-
+            } finally {
                 document = component.document
                 renderedComponents += component
-            } else {
-                if (equivalence.session.hasChanged) {
-                    equivalence.session.hasChanged = false
-                    equivalence.rerender()
-                }
-                // ensure that we swap the document inside the component
-                // so that the next rerender will utilize this new document.
-                component.document = equivalence.document
-                document = component.document
             }
 
             composition.components += component


### PR DESCRIPTION
This pull request aims to primarily minimize the memory consumption of the framework by comparing stateful props during component equivalence through hash codes of the values containing a reference or a copy of that stateful prop's value during initialization.

I believe that this pull request will help minimize memory consumption for components that accept stateful props as it will stop the framework from unnecessarily holding a reference, or even receiving a copy of the stateful prop's initial value whenever the component is initialized, but instead, simply holds an integer (32-bit at most) value.

In addition, this pull request identified and fixed some unrelated issues:
1. Components without equivalence weren't being included in reuse, preventing a minimized caching (although this may cause behavioral issues where we end up reusing a component when it shouldn't be reused, this will be investigated further).
2. Resolved a potential deadlock scenario in `Channel` which can stem from an unhandled exception when locking.