### PR TITLE
Prop retrieval without name needed to be provided.

### DIFF
--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -978,7 +978,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             operator fun getValue(
                 thisRef: Any?,
                 property: KProperty<*>,
-            ): Any? {
+            ): T? {
                 if (value != null) return value
                 val value = props[name ?: run {
                     name = property.name.lowercase()

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -999,6 +999,16 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
             }
         }
 
+        inner class EnsuredProp<T>(clazz: Class<T>) {
+            private val prop = Prop(clazz, true)
+            operator fun getValue(
+                thisRef: Any?,
+                property: KProperty<*>,
+            ): T {
+                return prop.getValue(this, property)!!
+            }
+        }
+
         private var beforeMountListeners = mutableListOf<ComponentBeforeMountSubscription>()
         private var afterMountListeners = mutableListOf<ComponentAfterMountSubscription>()
 
@@ -1091,7 +1101,7 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
          * @throws PropTypeMismatch when the type of the prop received does not match the expected type.
          * @throws UnknownPropException when there is no prop received with the name.
          */
-        inline fun <reified T> ensureProp(): Prop<T> = Prop(T::class.java, true)
+        inline fun <reified T> ensureProp(): EnsuredProp<T> = EnsuredProp(T::class.java)
 
         /**
          * [prop] gets the [prop] with the [name] as [T] type. If there are no props with the name, and with the


### PR DESCRIPTION
An incredibly great developer-experience enhancement wherein retrieving the props no longer needs the name of the prop to be specified given that the property name is already the same as the prop's name. This pull request provides the enhancement through Kotlin delegation properties wherein we can gain access to the property itself, giving us knowledge of the property name.

An example of this incredible change is:
```kotlin
- val acknowledgementMessage = ensureProp<String>("acknowledgementMessage")
+ val acknowledgementMessage by ensureProp<String>()

- val confirmationMessage = prop<String>("confirmationMessage")
+ val confirmationMessage by prop<String>()
```

This change inherently creates more memory usage (not significantly noticeable) and a bit more overhead as it creates an entire new Class for each property, but the developer experience improvement gained really helps, plus it reduces the likelihood of mistakes.