### PR TITLE
Allow access to various properties, such as `user`, `reakt`, `channel` and `messageAuthor` inside Reakt.

### DIFF
--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -3,6 +3,7 @@ package pw.mihou.reakt
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import org.javacord.api.DiscordApi
+import org.javacord.api.entity.DiscordEntity
 import org.javacord.api.entity.intent.Intent
 import org.javacord.api.entity.message.Message
 import org.javacord.api.entity.message.MessageBuilder
@@ -10,6 +11,7 @@ import org.javacord.api.entity.message.MessageUpdater
 import org.javacord.api.entity.message.component.ActionRow
 import org.javacord.api.entity.message.component.LowLevelComponent
 import org.javacord.api.entity.message.embed.EmbedBuilder
+import org.javacord.api.entity.user.User
 import org.javacord.api.interaction.callback.InteractionOriginalResponseUpdater
 import org.javacord.api.listener.GloballyAttachableListener
 import org.javacord.api.listener.message.MessageDeleteListener
@@ -61,7 +63,11 @@ typealias SuspendingReaktConstructor = suspend Reakt.() -> Unit
  * `event.R` method instead as it is mostly designed to enable this to work for your situation, or instead use the
  * available `interaction.R` method for interactions.
  */
-class Reakt internal constructor(private val api: DiscordApi, private val renderMode: RenderMode, private val lifetime: Duration = 1.days) {
+class Reakt internal constructor(
+    private val api: DiscordApi,
+    private val renderMode: RenderMode,
+    private val lifetime: Duration = 1.days
+) {
     private var rendered: Boolean = false
 
     internal var message: ReaktMessage? = null
@@ -147,6 +153,11 @@ class Reakt internal constructor(private val api: DiscordApi, private val render
         fun dealloc(key: String) {
             store.remove(key)
         }
+
+        /**
+         * Gets the [Reakt] instance that the [Reakt.Component] was created.
+         */
+        val reakt get() = this@Reakt
     }
 
     companion object {

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -6,6 +6,7 @@ import org.javacord.api.DiscordApi
 import org.javacord.api.entity.DiscordEntity
 import org.javacord.api.entity.intent.Intent
 import org.javacord.api.entity.message.Message
+import org.javacord.api.entity.message.MessageAuthor
 import org.javacord.api.entity.message.MessageBuilder
 import org.javacord.api.entity.message.MessageUpdater
 import org.javacord.api.entity.message.component.ActionRow
@@ -65,6 +66,8 @@ typealias SuspendingReaktConstructor = suspend Reakt.() -> Unit
  */
 class Reakt internal constructor(
     private val api: DiscordApi,
+    val user: User?,
+    val messageAuthor: MessageAuthor?,
     private val renderMode: RenderMode,
     private val lifetime: Duration = 1.days
 ) {
@@ -158,6 +161,19 @@ class Reakt internal constructor(
          * Gets the [Reakt] instance that the [Reakt.Component] was created.
          */
         val reakt get() = this@Reakt
+
+        /**
+         * Gets the [User] involved in this [Reakt.Component]'s creation. If the user is null, then
+         * you may want to try getting the message author instead since this is only available when
+         * there is a user provided, either through cache, or related.
+         */
+        val user get() = this@Reakt.user
+
+        /**
+         * Gets the [MessageAuthor] that was involved in this [Reakt]'s creation. If the message author is null,
+         * then this is likely an event that isn't related to messages, but rather an interaction.
+         */
+        val messageAuthor get() = this@Reakt.messageAuthor
     }
 
     companion object {

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -979,10 +979,48 @@ class Reakt internal constructor(
         internal fun hashCodeOfValue() = _value.get().hashCode()
     }
 
+    class Prop<T>(private val component: Reakt.Component, private val clazz: Class<T>, private val ensure: Boolean) {
+        private var name: String? = null
+        private var value: T? = null
+        operator fun getValue(
+            thisRef: Any?,
+            property: KProperty<*>,
+        ): T? {
+            if (value != null) return value
+            val value = component.props[name ?: run {
+                name = property.name.lowercase()
+                return@run name
+            }] ?: run {
+                if (ensure) {
+                    throw UnknownPropException(name!!)
+                }
+
+                return@run null
+            } ?: return null
+            if (value::class.java != clazz && !value::class.java.isAssignableFrom(clazz)) {
+                throw PropTypeMismatch(name!!, clazz, value::class.java)
+            }
+            @Suppress("UNCHECKED_CAST")
+            this.value = value as T
+            return this.value
+        }
+    }
+
+    class EnsuredProp<T>(component: Reakt.Component, clazz: Class<T>) {
+        private val prop = Prop(component, clazz, true)
+        operator fun getValue(
+            thisRef: Any?,
+            property: KProperty<*>,
+        ): T {
+            return prop.getValue(this, property)!!
+        }
+    }
+
     inner class Component internal constructor(
         private val qualifiedName: String,
         private val constructor: ComponentConstructor,
     ) {
+
         private var beforeMountListeners = mutableListOf<ComponentBeforeMountSubscription>()
         private var afterMountListeners = mutableListOf<ComponentAfterMountSubscription>()
 
@@ -1053,6 +1091,29 @@ class Reakt internal constructor(
          * @return the prop's value.
          */
         fun anyProp(name: String): Any? = props[name.lowercase()]
+
+        /**
+         * Gets the [prop] by using delegated properties, enabling retrieval through the name of the property
+         * instead of typing the property name over and over again.
+         *
+         * @return a delegatable [Prop] instance that will get the value of the prop with the same name
+         * as the assigned property.
+         * @throws PropTypeMismatch when the type of the prop received does not match the expected type.
+         * @throws UnknownPropException when there is no prop received with the name.
+         */
+        inline fun <reified T> prop(): Prop<T> = Prop(this, T::class.java, false)
+
+        /**
+         * Gets the [prop] by using delegated properties, enabling retrieval through the name of the property
+         * instead of typing the property name over and over again. This ensures that the prop exists, otherwise
+         * throws an [UnknownPropException].
+         *
+         * @return a delegatable [Prop] instance that will get the value of the prop with the same name
+         * as the assigned property.
+         * @throws PropTypeMismatch when the type of the prop received does not match the expected type.
+         * @throws UnknownPropException when there is no prop received with the name.
+         */
+        inline fun <reified T> ensureProp(): EnsuredProp<T> = EnsuredProp(this, T::class.java)
 
         /**
          * [prop] gets the [prop] with the [name] as [T] type. If there are no props with the name, and with the

--- a/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
@@ -6,7 +6,6 @@ import pw.mihou.reakt.ReaktConstructor
 import pw.mihou.reakt.SuspendingReaktConstructor
 import pw.mihou.reakt.deferrable.ReaktAutoResponse
 import pw.mihou.reakt.deferrable.autoDefer
-import pw.mihou.reakt.utils.coroutine
 import pw.mihou.reakt.utils.suspend
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration
@@ -30,6 +29,7 @@ fun <Interaction: InteractionBase> Interaction.R(ephemeral: Boolean, lifetime: D
         api = this.api,
         user = this.user,
         messageAuthor = null,
+        textChannel = this.channel.orElseThrow(),
         Reakt.RenderMode.Interaction,
         lifetime
     )

--- a/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/InteractionAdapters.kt
@@ -26,7 +26,13 @@ import kotlin.time.Duration.Companion.hours
  */
 @JvmSynthetic
 fun <Interaction: InteractionBase> Interaction.R(ephemeral: Boolean, lifetime: Duration = 1.hours, reakt: ReaktConstructor): CompletableFuture<ReaktAutoResponse> {
-    val r = Reakt(this.api, Reakt.RenderMode.Interaction, lifetime)
+    val r = Reakt(
+        api = this.api,
+        user = this.user,
+        messageAuthor = null,
+        Reakt.RenderMode.Interaction,
+        lifetime
+    )
     return autoDefer(ephemeral) {
         reakt(r)
 

--- a/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
@@ -3,13 +3,13 @@ package pw.mihou.reakt.adapters
 import pw.mihou.reakt.Reakt
 
 import org.javacord.api.DiscordApi
+import org.javacord.api.entity.channel.TextChannel
 import org.javacord.api.entity.message.Message
 import org.javacord.api.entity.message.Messageable
 import org.javacord.api.entity.user.User
 import org.javacord.api.event.message.CertainMessageEvent
 import pw.mihou.reakt.ReaktConstructor
 import pw.mihou.reakt.SuspendingReaktConstructor
-import pw.mihou.reakt.utils.coroutine
 import pw.mihou.reakt.utils.suspend
 import java.util.concurrent.CompletableFuture
 import kotlin.jvm.optionals.getOrNull
@@ -43,6 +43,7 @@ fun CertainMessageEvent.R(lifetime: Duration = 1.hours, react: Reakt.() -> Unit)
         api = this.api,
         user = this.messageAuthor.asUser().getOrNull(),
         messageAuthor = this.messageAuthor,
+        textChannel = this.channel,
         Reakt.RenderMode.Message,
         lifetime
     )
@@ -68,6 +69,7 @@ fun Messageable.R(api: DiscordApi, lifetime: Duration = 1.hours, react: ReaktCon
         api = api,
         user = if (this is User) this else null,
         messageAuthor = null,
+        textChannel = if (this is User) null else if (this is TextChannel) this else null,
         Reakt.RenderMode.Message,
         lifetime
     )
@@ -90,6 +92,7 @@ fun Message.R(lifetime: Duration = 1.hours, react: ReaktConstructor): Completabl
         api = api,
         user = this.userAuthor.getOrNull(),
         messageAuthor = this.author,
+        textChannel = this.channel,
         Reakt.RenderMode.Message,
         lifetime
     )

--- a/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
+++ b/src/main/kotlin/pw/mihou/reakt/adapters/MessageAdapters.kt
@@ -5,12 +5,14 @@ import pw.mihou.reakt.Reakt
 import org.javacord.api.DiscordApi
 import org.javacord.api.entity.message.Message
 import org.javacord.api.entity.message.Messageable
+import org.javacord.api.entity.user.User
 import org.javacord.api.event.message.CertainMessageEvent
 import pw.mihou.reakt.ReaktConstructor
 import pw.mihou.reakt.SuspendingReaktConstructor
 import pw.mihou.reakt.utils.coroutine
 import pw.mihou.reakt.utils.suspend
 import java.util.concurrent.CompletableFuture
+import kotlin.jvm.optionals.getOrNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 
@@ -37,7 +39,13 @@ private fun CompletableFuture<Message>.ack(react: Reakt): CompletableFuture<Mess
  */
 @JvmSynthetic
 fun CertainMessageEvent.R(lifetime: Duration = 1.hours, react: Reakt.() -> Unit): CompletableFuture<Message> {
-    val r = Reakt(this.api, Reakt.RenderMode.Message, lifetime)
+    val r = Reakt(
+        api = this.api,
+        user = this.messageAuthor.asUser().getOrNull(),
+        messageAuthor = this.messageAuthor,
+        Reakt.RenderMode.Message,
+        lifetime
+    )
     react(r)
 
     return r.messageBuilder!!
@@ -56,7 +64,13 @@ fun CertainMessageEvent.R(lifetime: Duration = 1.hours, react: Reakt.() -> Unit)
  */
 @JvmSynthetic
 fun Messageable.R(api: DiscordApi, lifetime: Duration = 1.hours, react: ReaktConstructor): CompletableFuture<Message> {
-    val r = Reakt(api, Reakt.RenderMode.Message, lifetime)
+    val r = Reakt(
+        api = api,
+        user = if (this is User) this else null,
+        messageAuthor = null,
+        Reakt.RenderMode.Message,
+        lifetime
+    )
     react(r)
 
     return r.messageBuilder!!.send(this).ack(r)
@@ -72,7 +86,13 @@ fun Messageable.R(api: DiscordApi, lifetime: Duration = 1.hours, react: ReaktCon
  * @param react the entire procedure over how rendering the response works.
  */
 fun Message.R(lifetime: Duration = 1.hours, react: ReaktConstructor): CompletableFuture<Message> {
-    val r = Reakt(api, Reakt.RenderMode.Message, lifetime)
+    val r = Reakt(
+        api = api,
+        user = this.userAuthor.getOrNull(),
+        messageAuthor = this.author,
+        Reakt.RenderMode.Message,
+        lifetime
+    )
     react(r)
 
     r.acknowledgeUpdate(this)


### PR DESCRIPTION
Accessing the base `Reakt` instance can be important for components that rely on it for deleting the message, or related actions. As such, exposing the `reakt` instance for components inside their session property serves as a vital gateway to this. This pull request simply exposes the  `reakt` instance through the `ComponentSession`.