### PR TITLE
Adds "DEBUG" and "PRODUCTION" mode for Reakt.

### DIFF
--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -1392,9 +1392,7 @@ class Reakt internal constructor(
                 view.uuids += uuid
             }
 
-            if (textContent != null) {
-                view.contents = textContent
-            }
+            view.contents = textContent
         }
     }
 

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -635,6 +635,7 @@ class Reakt internal constructor(
 
     @Suppress("NOTHING_TO_INLINE")
     internal inline fun detectInvalidWritableDeclaration() {
+        if (mode == Mode.PRODUCTION) return
         val isInsideRenderMethod =
             StackWalker.getInstance().walk { stream ->
                 val frame =

--- a/src/main/kotlin/pw/mihou/reakt/Reakt.kt
+++ b/src/main/kotlin/pw/mihou/reakt/Reakt.kt
@@ -27,6 +27,7 @@ import pw.mihou.reakt.exceptions.*
 import pw.mihou.reakt.logger.LoggingAdapter
 import pw.mihou.reakt.logger.adapters.DefaultLoggingAdapter
 import pw.mihou.reakt.logger.adapters.FastLoggingAdapter
+import pw.mihou.reakt.settings.Mode
 import pw.mihou.reakt.utils.coroutine
 import pw.mihou.reakt.uuid.UuidGenerator
 import java.util.concurrent.CompletableFuture
@@ -269,6 +270,17 @@ class Reakt internal constructor(
          */
         @JvmField @Volatile
         var autoDeferAfterMilliseconds: Long = 2350
+
+        /**
+         * Specifies the mode that Reakt should be in, this can be either [Mode.DEBUG] or [Mode.PRODUCTION].
+         * During [Mode.DEBUG], Reakt will have stricter analysis, such as having the "no state creation inside
+         * render methods" and related, which will slow down performance, but will make it safer to debug problems.
+         *
+         * Meanwhile, in [Mode.PRODUCTION], Reakt will disable specific features that are best for debug only,
+         * enabling some performance gains, but losing some safeties.
+         */
+        @JvmField @Volatile
+        var mode: Mode = Mode.DEBUG
 
         internal const val RESERVED_VALUE_KEY = "&[value\$]"
 

--- a/src/main/kotlin/pw/mihou/reakt/settings/Mode.kt
+++ b/src/main/kotlin/pw/mihou/reakt/settings/Mode.kt
@@ -1,0 +1,6 @@
+package pw.mihou.reakt.settings
+
+enum class Mode {
+    DEBUG,
+    PRODUCTION
+}


### PR DESCRIPTION
The use of StackWalker is not so ideal as it would consume some decently significant compute time and resources just to check whether the state was declared in a `render` method. As such, adding a switch for `DEBUG` and `PRODUCTION` would make more sense.

In this pull request,  we add a new `Reakt.mode` setting that will disable checks like those which are more helpful in `DEBUG` than in `PRODUCTION`, ensuring that during `PRODUCTION`, we use as much performance as we could gather. In further enhancements following this pull request, we could add more changes that may be bad for debugging, but incredible for performance if there are any found.